### PR TITLE
768px이하에서 viewport를 넘기는 문제

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@ permalink: /
     </a>
 </div>
 
-<section id="about" class="features">
+<section id="about" class="features container-fluid">
     <div class="row">
         <div class="col-lg-8 col-lg-offset-2 text-center m-t-lg m-b-lg">
             <p>커뮤니티 활동의 첫 단추,</p>


### PR DESCRIPTION
768px 이하에서 viewport를 초과하여 여백이 발생하는 문제를 해결하였습니다. 기존 사이트를 사파리 혹은 구글 개발자 도구 (신기하게도 구글 크롬에서는 개발자 도구에서만 확인 가능하더군요)에서 확인 가능합니다.
bootstrap 에서 row가 좌우로 -15px씩 margin을 가져가는 문제로 상위 section에 container-fluid class를 추가하여 해결하였습니다.
